### PR TITLE
Fix section header type

### DIFF
--- a/src/wikitext.ts
+++ b/src/wikitext.ts
@@ -122,7 +122,7 @@ export interface CategoryLink extends Link {
 
 export interface Section {
 	level: number;
-	header: string;
+	header: string | null;
 	index: number;
 	content?: string;
 }


### PR DESCRIPTION
Section header type changed from `string` to `string | null` because "The top is represented as level 1, with header `null`".

https://github.com/siddharthvp/mwn/blob/4442b4a46317e4f5abfb1c73e9068e9e3eee59bd/src/wikitext.ts#L86-L96