### PR TITLE
Fix section content type

### DIFF
--- a/src/wikitext.ts
+++ b/src/wikitext.ts
@@ -124,7 +124,7 @@ export interface Section {
 	level: number;
 	header: string | null;
 	index: number;
-	content?: string;
+	content: string;
 }
 
 /**
@@ -476,7 +476,7 @@ export function parseSections(text: string): Section[] {
 			level: 1,
 			header: null,
 			index: 0,
-		},
+		} as Section,
 	];
 	let match;
 	while ((match = rgx.exec(text))) {
@@ -485,7 +485,7 @@ export function parseSections(text: string): Section[] {
 			level: match[1].length,
 			header: match[2].trim(),
 			index: match.index,
-		});
+		} as Section);
 	}
 	let n = sections.length;
 	for (let i = 0; i < n - 1; i++) {


### PR DESCRIPTION
The section content type is always `string`, never `undefined`.

I could use the empty string (`content: ''`) instead of `as Section` when adding a section object. But this is unnecessary output code because the `slice` method overwrites the empty string.