### PR TITLE
Fix edit transform return type

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -119,6 +119,11 @@ export interface MwnOptions {
 	suppressInvalidDateWarning?: boolean;
 }
 
+export type EditTransform = (rev: {
+	content: string;
+	timestamp: string;
+}) => string | ApiEditPageParams | Promise<string | ApiEditPageParams>;
+
 type editConfigType = {
 	conflictRetries?: number;
 	suppressNochangeWarning?: boolean;
@@ -976,10 +981,7 @@ export class Mwn {
 	 */
 	async edit(
 		title: string | number,
-		transform: (rev: {
-			content: string;
-			timestamp: string;
-		}) => string | ApiEditPageParams | Promise<string | ApiEditPageParams>,
+		transform: EditTransform,
 		editConfig?: editConfigType
 	): Promise<ApiEditResponse> {
 		editConfig = editConfig || this.options.editConfig;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -976,7 +976,10 @@ export class Mwn {
 	 */
 	async edit(
 		title: string | number,
-		transform: (rev: { content: string; timestamp: string }) => string | ApiEditPageParams,
+		transform: (rev: {
+			content: string;
+			timestamp: string;
+		}) => string | ApiEditPageParams | Promise<string | ApiEditPageParams>,
 		editConfig?: editConfigType
 	): Promise<ApiEditResponse> {
 		editConfig = editConfig || this.options.editConfig;

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,6 +1,6 @@
 import { MwnError } from './error';
 
-import type { Mwn, MwnTitle } from './bot';
+import type { Mwn, MwnTitle, EditTransform } from './bot';
 import type {
 	ApiDeleteParams,
 	ApiEditPageParams,
@@ -155,12 +155,7 @@ export interface MwnPage extends MwnTitle {
 	 * @see https://wikiwho.wmflabs.org/
 	 */
 	queryAuthors(): Promise<AuthorshipData>;
-	edit(
-		transform: (rev: {
-			content: string;
-			timestamp: string;
-		}) => string | ApiEditPageParams | Promise<string | ApiEditPageParams>
-	): Promise<any>;
+	edit(transform: EditTransform): Promise<any>;
 	save(text: string, summary?: string, options?: ApiEditPageParams): Promise<any>;
 	newSection(header: string, message: string, additionalParams?: ApiEditPageParams): Promise<any>;
 	move(target: string, summary: string, options?: ApiMoveParams): Promise<any>;
@@ -656,12 +651,7 @@ export default function (bot: Mwn): MwnPageStatic {
 		/**** Post operations *****/
 		// Defined in bot.js
 
-		edit(
-			transform: (rev: {
-				content: string;
-				timestamp: string;
-			}) => string | ApiEditPageParams | Promise<string | ApiEditPageParams>
-		) {
+		edit(transform: EditTransform) {
 			return bot.edit(this.toString(), transform);
 		}
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -155,7 +155,12 @@ export interface MwnPage extends MwnTitle {
 	 * @see https://wikiwho.wmflabs.org/
 	 */
 	queryAuthors(): Promise<AuthorshipData>;
-	edit(transform: (rev: { content: string; timestamp: string }) => string | ApiEditPageParams): Promise<any>;
+	edit(
+		transform: (rev: {
+			content: string;
+			timestamp: string;
+		}) => string | ApiEditPageParams | Promise<string | ApiEditPageParams>
+	): Promise<any>;
 	save(text: string, summary?: string, options?: ApiEditPageParams): Promise<any>;
 	newSection(header: string, message: string, additionalParams?: ApiEditPageParams): Promise<any>;
 	move(target: string, summary: string, options?: ApiMoveParams): Promise<any>;
@@ -651,7 +656,12 @@ export default function (bot: Mwn): MwnPageStatic {
 		/**** Post operations *****/
 		// Defined in bot.js
 
-		edit(transform: (rev: { content: string; timestamp: string }) => string | ApiEditPageParams) {
+		edit(
+			transform: (rev: {
+				content: string;
+				timestamp: string;
+			}) => string | ApiEditPageParams | Promise<string | ApiEditPageParams>
+		) {
 			return bot.edit(this.toString(), transform);
 		}
 


### PR DESCRIPTION
Return type of `transform` parameter of `edit` method changed from `string | ApiEditPageParams` to `string | ApiEditPageParams | Promise<string | ApiEditPageParams>` because "This function should return... **or a promise** providing one of those".

https://github.com/siddharthvp/mwn/blob/f37a887046feb3dc762376f8874412bfaace682d/src/bot.ts#L962-L966