### PR TITLE
Fix the bug that fillRequestOptions() does not respect method option

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -38,6 +38,9 @@ export class Request {
 	}
 
 	getMethod() {
+		if (this.requestParams.method !== undefined) {
+			return this.requestParams.method;
+		}
 		if (this.apiParams.action === 'query') {
 			return 'get';
 		}


### PR DESCRIPTION
It may cause 414 (URI Too Long) error for massQuery().