### PR TITLE
docs: fix incorrect upload example code

### DIFF
--- a/website/docs/3-other-basic-operations.md
+++ b/website/docs/3-other-basic-operations.md
@@ -52,7 +52,7 @@ await bot.parseTitle('Page name', additionalOptions);
 Upload a file from your system to the wiki:
 
 ```js
-await bot.upload('File title', '/path/to/file', 'comment', customParams);
+await bot.upload('/path/to/file', 'File title', 'comment', customParams);
 ```
 
 Download a file from the wiki:


### PR DESCRIPTION
The method signature is actually `upload(filepath: string, title: string, text: string, options?: ApiUploadParams)`. The `filepath` and `title` parameters were swapped in the docs.

![image](https://github.com/user-attachments/assets/5fb18832-25d1-402e-a2df-497bbe088202)
