### PR TITLE
Fix the casing of "mwn" to "Mwn" in dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/siddharthvp/mwn/badge.svg?branch=master)](https://coveralls.io/github/siddharthvp/mwn?branch=master)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
-**Quick links: [Getting Started](https://mwn.toolforge.org/docs/getting-started) — [GitHub](https://github.com/siddharthvp/mwn) — [NPM](https://www.npmjs.com/package/mwn) — [User Documentation](https://mwn.toolforge.org/) — [API Documentation](https://mwn.toolforge.org/docs/api/classes/mwn.html)**
+**Quick links: [Getting Started](https://mwn.toolforge.org/docs/getting-started) — [GitHub](https://github.com/siddharthvp/mwn) — [NPM](https://www.npmjs.com/package/mwn) — [User Documentation](https://mwn.toolforge.org/) — [API Documentation](https://mwn.toolforge.org/docs/api/classes/Mwn.html)**
 
 **Mwn** is a modern and comprehensive MediaWiki bot framework for Node.js, originally adapted from [mwbot](https://github.com/Fannon/mwbot).
 

--- a/website/docs/12-logging.md
+++ b/website/docs/12-logging.md
@@ -13,4 +13,4 @@ log('[E] Error message');
 
 Based on the character within `[]`, colouration happens automatically.
 
-To configure logging, use [Mwn.setLoggingConfig()](https://mwn.toolforge.org/docs/api/classes/mwn.html#setloggingconfig). Please note that logging configuration is global and shared across all Mwn instances.
+To configure logging, use [Mwn.setLoggingConfig()](https://mwn.toolforge.org/docs/api/classes/Mwn.html#setloggingconfig). Please note that logging configuration is global and shared across all Mwn instances.

--- a/website/docs/5-direct-api-calls.md
+++ b/website/docs/5-direct-api-calls.md
@@ -20,7 +20,7 @@ Mwn provides a great number of convenience methods so that you can avoid writing
 
 #### Raw web requests
 
-Mwn also exposes the lower level [`rawRequest`](https://mwn.toolforge.org/docs/api/classes/mwn.html#rawrequest) method using which you can make requests to any web API. Its format is based on axios.
+Mwn also exposes the lower level [`rawRequest`](https://mwn.toolforge.org/docs/api/classes/Mwn.html#rawrequest) method using which you can make requests to any web API. Its format is based on axios.
 
 ```js
 let response = await bot.rawRequest({


### PR DESCRIPTION
Links to "mwn.html" are dead. This patch fixes these dead links.